### PR TITLE
Fix sitemap route for graduate page

### DIFF
--- a/src/sitemapRoutes.js
+++ b/src/sitemapRoutes.js
@@ -12,7 +12,7 @@ export default (
     <Route path="/about_professor"/>
     <Route path="/achievements"/>
     <Route path="/members" />
-    <Route path="/graduates"/>
+    <Route path="/graduate"/>
     <Route path="/recruit" />
     <Route path="/FAQ" />
     <Route path="/Blog" />


### PR DESCRIPTION
sitemapRoutes.js에 정의된 졸업생 페이지 경로가 실제 라우트와 달라 수정했습니다.
기존 /graduates 경로를 실제 App.js에 정의된 /graduate로 변경하여 sitemap이 존재하지 않는 페이지를 가리키지 않도록 맞췄습니다.